### PR TITLE
Remove custom config to accept 2 trailing spaces for mdl

### DIFF
--- a/.github/workflows/mdl_style.rb
+++ b/.github/workflows/mdl_style.rb
@@ -7,6 +7,3 @@ exclude_tag :line_length
 # Exclude rules MD002 and MD041 (`hugo` puts metadata at the top of content file which contains the top level title/header)
 exclude_rule 'MD002'
 exclude_rule 'MD041'
-
-# Set accepted trailing spaces to a maximum of 2 (used to break a line) for the MD009 rule
-rule 'MD009', :br_spaces => 2


### PR DESCRIPTION
https://github.com/markdownlint/markdownlint/pull/452