### PR TITLE
Fix misuse of "hardly" in "Arch Linux now has an official WSL image!"

### DIFF
--- a/content/blog/archlinux-official-wsl-image.md
+++ b/content/blog/archlinux-official-wsl-image.md
@@ -12,7 +12,7 @@ This subject was actually explored a few years back but got turned down due to m
 
 ## WSL? For what, for who?
 
-Despite being employed as a Linux system engineer, I personally never had the chance to work for a company that allowed me to run Linux on my workstation yet... The usage of Windows was always hard-required by their "internal policy" (whatever that means). It's unfortunately pretty safe to say that I'm not the only person in that situation.  
+Despite being employed as a Linux system engineer, I personally never had the chance to work for a company that allowed me to run Linux on my workstation yet... The usage of Windows was always required by their "internal policy" (whatever that means). It's unfortunately pretty safe to say that I'm not the only person in that situation.  
 In such case, `WSL` acts as a pretty decent and reliable workaround (from my experience), allowing one to run a Linux environment in a fairly transparent way directly from a Windows system; providing a direct access to every Linux tools, *hopefully* without getting in the way of potential companies' requirements / restrictions.
 
 More generally speaking, `WSL` provides an easy and straightforward way to get access to a full Linux environment, allowing to perform Linux development / testing or simply to try & run a Linux distribution directly from Windows; increasing its discoverability & accessibility.

--- a/content/blog/archlinux-official-wsl-image.md
+++ b/content/blog/archlinux-official-wsl-image.md
@@ -12,7 +12,7 @@ This subject was actually explored a few years back but got turned down due to m
 
 ## WSL? For what, for who?
 
-Despite being employed as a Linux system engineer, I personally never had the chance to work for a company that allowed me to run Linux on my workstation yet... The usage of Windows always was *hardly* required by their "internal policy" (whatever that means). It's unfortunately pretty safe to say that I'm not the only person in that situation.  
+Despite being employed as a Linux system engineer, I personally never had the chance to work for a company that allowed me to run Linux on my workstation yet... The usage of Windows was always hard-required by their "internal policy" (whatever that means). It's unfortunately pretty safe to say that I'm not the only person in that situation.  
 In such case, `WSL` acts as a pretty decent and reliable workaround (from my experience), allowing one to run a Linux environment in a fairly transparent way directly from a Windows system; providing a direct access to every Linux tools, *hopefully* without getting in the way of potential companies' requirements / restrictions.
 
 More generally speaking, `WSL` provides an easy and straightforward way to get access to a full Linux environment, allowing to perform Linux development / testing or simply to try & run a Linux distribution directly from Windows; increasing its discoverability & accessibility.


### PR DESCRIPTION
In the context it is used here, "hardly" would mean "barely" or "almost not", as in "it was ALMOST not required by my company's internal policy", which tripped me up while reading. This edit is still a bit clunky, but in my opinion is somewhat clearer.