### PR TITLE
Remove misuse of "hardly" in "Arch Linux now has an official WSL image!" (#101)

### DIFF
--- a/content/blog/archlinux-official-wsl-image.md
+++ b/content/blog/archlinux-official-wsl-image.md
@@ -12,7 +12,7 @@ This subject was actually explored a few years back but got turned down due to m
 
 ## WSL? For what, for who?
 
-Despite being employed as a Linux system engineer, I personally never had the chance to work for a company that allowed me to run Linux on my workstation yet... The usage of Windows always was *hardly* required by their "internal policy" (whatever that means). It's unfortunately pretty safe to say that I'm not the only person in that situation.  
+Despite being employed as a Linux system engineer, I personally never had the chance to work for a company that allowed me to run Linux on my workstation yet... The usage of Windows was always required by their "internal policy" (whatever that means). It's unfortunately pretty safe to say that I'm not the only person in that situation.  
 In such case, `WSL` acts as a pretty decent and reliable workaround (from my experience), allowing one to run a Linux environment in a fairly transparent way directly from a Windows system; providing a direct access to every Linux tools, *hopefully* without getting in the way of potential companies' requirements / restrictions.
 
 More generally speaking, `WSL` provides an easy and straightforward way to get access to a full Linux environment, allowing to perform Linux development / testing or simply to try & run a Linux distribution directly from Windows; increasing its discoverability & accessibility.

--- a/public/blog/archlinux-official-wsl-image/index.html
+++ b/public/blog/archlinux-official-wsl-image/index.html
@@ -212,7 +212,7 @@ This subject was actually explored a few years back but got turned down due to m
 
     ,
         "url" : "https:\/\/antiz.fr\/blog\/archlinux-official-wsl-image\/",
-        "wordCount" : "954",
+        "wordCount" : "953",
         "genre" : [ ],
         "keywords" : [ ]
     }
@@ -439,7 +439,7 @@ This subject was actually explored a few years back but got turned down due to m
 <p>A few months ago, the eventuality of building and providing an official Arch Linux <a href="https://learn.microsoft.com/en-us/windows/wsl/about">WSL</a> image (Windows Subsystem for Linux - a Microsoft solution allowing to run Linux environments within Windows) was brought to the table within the Arch Linux staff.</p>
 <p>This subject was actually explored a few years back but got turned down due to multiple concerns and lack of interest at the time. But <code>WSL</code> have come a long way since then and minds evolved to the point where people were generally willing to reconsider it.</p>
 <h2 id="wsl-for-what-for-who">WSL? For what, for who?</h2>
-<p>Despite being employed as a Linux system engineer, I personally never had the chance to work for a company that allowed me to run Linux on my workstation yet&hellip; The usage of Windows always was <em>hardly</em> required by their &ldquo;internal policy&rdquo; (whatever that means). It&rsquo;s unfortunately pretty safe to say that I&rsquo;m not the only person in that situation.<br>
+<p>Despite being employed as a Linux system engineer, I personally never had the chance to work for a company that allowed me to run Linux on my workstation yet&hellip; The usage of Windows was always required by their &ldquo;internal policy&rdquo; (whatever that means). It&rsquo;s unfortunately pretty safe to say that I&rsquo;m not the only person in that situation.<br>
 In such case, <code>WSL</code> acts as a pretty decent and reliable workaround (from my experience), allowing one to run a Linux environment in a fairly transparent way directly from a Windows system; providing a direct access to every Linux tools, <em>hopefully</em> without getting in the way of potential companies&rsquo; requirements / restrictions.</p>
 <p>More generally speaking, <code>WSL</code> provides an easy and straightforward way to get access to a full Linux environment, allowing to perform Linux development / testing or simply to try &amp; run a Linux distribution directly from Windows; increasing its discoverability &amp; accessibility.</p>
 <p>However, the lack of official Arch Linux image for <code>WSL</code> <em>at the time</em> either suggested the use of a different distribution or implied users to rely on unofficial <code>WSL</code> images for Arch Linux, which quality may vary.</p>


### PR DESCRIPTION
In the context it is used here, "hardly" would mean "barely" or "almost not", as in "it was ALMOST not required by my company's internal policy".

After a second thought, the "hardly" mention doesn't bring much on its own. If it feels confusing or clunky, then let's drop it.